### PR TITLE
Keybind, Save/LogAll changes, message persistence

### DIFF
--- a/ShowKSP2EventsProject/MessageListener.cs
+++ b/ShowKSP2EventsProject/MessageListener.cs
@@ -76,7 +76,9 @@ namespace ShowKSP2Events
             messageInfo.IsSticky = true;
             messageInfo.IsStale = false;
 
-            if (messageInfo.IsLogging)
+            // Log message if user manually clicked the log button OR if LogAll is set, but user didn't ignore the message
+            if (messageInfo.IsLogging
+                || (Settings.LogAll && !messageInfo.IsIgnored))
                 _logger.LogInfo($"Message {messageInfo.TypeName} triggered at {messageInfo.DateTimeOfLastHit}. Hit number: {messageInfo.Hits}.");
 
             if (!messageInfo.IsPermaSticky && !messageInfo.IsSticky)
@@ -128,16 +130,25 @@ namespace ShowKSP2Events
             }
         }
 
-        public void OnExportClicked()
+        public void OnSaveClicked()
         {
+            /*
             var x = new ExportMessages(Messages.FindAll(m => m.Hits > 0));
             x.Export();
+            */
+
+            var x = new ExportMessages(Messages);
+            x.WriteAllToLog();
         }
 
         public void OnWriteAllToLogClicked()
         {
+            /*
             var x = new ExportMessages(Messages);
             x.WriteAllToLog();
+            */
+            Settings.LogAll = !Settings.LogAll;
+            Settings.Save();
         }
 
         public void OnClearClicked()

--- a/ShowKSP2EventsProject/MessageListener.cs
+++ b/ShowKSP2EventsProject/MessageListener.cs
@@ -41,7 +41,7 @@ namespace ShowKSP2Events
                     var action = (Action<MessageCenterMessage>)Delegate.CreateDelegate(typeof(Action<MessageCenterMessage>), this, method);
 
                     var specificMethod = messageCenterType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-                        .Where(m => m.Name == "Subscribe")
+                        .Where(m => m.Name == "PersistentSubscribe")
                         .Select(m => new { Method = m, Parameters = m.GetParameters() })
                         .Where(x => x.Parameters.Length == 1 && x.Parameters[0].ParameterType.IsGenericType)
                         .Where(x => x.Parameters[0].ParameterType.GetGenericTypeDefinition() == typeof(Action<>))

--- a/ShowKSP2EventsProject/Settings.cs
+++ b/ShowKSP2EventsProject/Settings.cs
@@ -9,6 +9,7 @@ namespace ShowKSP2Events
         public static float JustHit = 1.0f;
         public static float StickyDuration = 20.0f;
         public static float DurationTillPruned = 60.0f;
+        public static bool LogAll;
 
         private static ManualLogSource _logger = Logger.CreateLogSource("ShowKSP2Events.Settings");
 
@@ -81,6 +82,8 @@ namespace ShowKSP2Events
         [JsonProperty]
         internal float JustHit;
         [JsonProperty]
+        internal bool LogAll;
+        [JsonProperty]
         internal List<SettingsMessageData> SavedMessages;
 
         internal SettingsData()
@@ -88,6 +91,7 @@ namespace ShowKSP2Events
             StickyDuration = Settings.StickyDuration;
             DurationTillPruned = Settings.DurationTillPruned;
             JustHit = Settings.JustHit;
+            LogAll = Settings.LogAll;
 
             var savedMessages = MessageListener.Instance.Messages
                 .Where(m => m.IsIgnored || m.IsLogging || m.IsPermaSticky);

--- a/ShowKSP2EventsProject/ShowKSP2Events.cs
+++ b/ShowKSP2EventsProject/ShowKSP2Events.cs
@@ -65,6 +65,12 @@ public class ShowKSP2Events : BaseSpaceWarpPlugin
 
     private void Update()
     {
+        // Keyboard shortcut for opening UI
+        if (Input.GetKey(KeyCode.LeftAlt) && Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.E))
+        {
+            _isWindowOpen = !_isWindowOpen;
+        }
+        
         try
         {
             MessageListener.Instance.CheckStickies();

--- a/ShowKSP2EventsProject/Styles.cs
+++ b/ShowKSP2EventsProject/Styles.cs
@@ -13,7 +13,7 @@ namespace ShowKSP2Events
         public static GUIStyle MessageJustHitColor;
         public static GUIStyle Hits;
         public static GUIStyle PermaSticky;
-        public static GUIStyle ExportButton;
+        public static GUIStyle SaveButton;
         public static GUIStyle SettingsButton;
         public static GUIStyle IgnoreButton;
         public static GUIStyle LogButtonDisabledButton;
@@ -73,7 +73,7 @@ namespace ShowKSP2Events
                 padding = new RectOffset(-2, -2, -2, -2)
             };
 
-            ExportButton = new GUIStyle(SpaceWarpUISkin.button)
+            SaveButton = new GUIStyle(SpaceWarpUISkin.button)
             {
                 fixedHeight = 20,
                 fixedWidth = 20,

--- a/ShowKSP2EventsProject/Textures.cs
+++ b/ShowKSP2EventsProject/Textures.cs
@@ -11,7 +11,7 @@ namespace ShowKSP2Events
 
         public static Texture2D PermaStickyActive;
         public static Texture2D PermaStickyInactive;
-        public static Texture2D Export;
+        public static Texture2D FloppyDisk;
         public static Texture2D Settings;
         public static Texture2D Cross;
         public static Texture2D Plus;
@@ -25,7 +25,7 @@ namespace ShowKSP2Events
 
             PermaStickyActive = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/permasticky_active.png");
             PermaStickyInactive = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/permasticky_inactive.png");
-            Export = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/export-30.png");
+            FloppyDisk = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/export-30.png");
             Settings = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/settings-20.png");
             Cross = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/cross.png");
             Plus = LoadTexture($"{_plugin.SpaceWarpMetadata.ModID}/images/plus.png");

--- a/ShowKSP2EventsProject/UI.cs
+++ b/ShowKSP2EventsProject/UI.cs
@@ -61,15 +61,17 @@ namespace ShowKSP2Events
                 _tillPrunedTemp = Settings.DurationTillPruned;
                 _showSettings = !_showSettings;
             }
-            if (GUILayout.Button(Textures.Export, Styles.ExportButton))
+            if (GUILayout.Button(Textures.FloppyDisk, Styles.SaveButton))
             {
-                MessageListener.Instance.OnExportClicked();
-                PrintStatusBarMessage("Exported all messages to plugin folder.");
+                MessageListener.Instance.OnSaveClicked();
+                //PrintStatusBarMessage("Exported all messages to plugin folder.");
+                PrintStatusBarMessage($"All {MessageListener.Instance.Messages.Count} messages that the game uses written to log.");
             }
             if (GUILayout.Button("LogAll", Styles.LogAllButton))
             {
                 MessageListener.Instance.OnWriteAllToLogClicked();
-                PrintStatusBarMessage("All message types written to log.");
+                //PrintStatusBarMessage("All message types written to log.");
+                PrintStatusBarMessage($"Logging for all messages set to: {Settings.LogAll}.");
             }
 
             GUILayout.FlexibleSpace();


### PR DESCRIPTION
- keybind CTRL + ALT + E now toggles the ShowKSP2Events window, useful for displaying the window in main menu where the app bar isn't available yet
- changed functionality of Save (floppy disk) and LogAll buttons:
  - clicking on Save now logs every existing message to the log once, instead of exporting to an external file
  - clicking on LogAll now toggles logging of every message hit to the log, except for ignored messages
- message subscriptions will now persist after going back to the main menu
